### PR TITLE
refactor direct call to xdmp:document-get, for module database deployment

### DIFF
--- a/deploy/ml-config.xml
+++ b/deploy/ml-config.xml
@@ -626,6 +626,7 @@
 -->
       </element-attribute-word-lexicons>
     </database>
+
     <!--Create Application Modules Database-->
     <database>
       <database-name>@ml.modules-db</database-name>
@@ -655,9 +656,21 @@
       <one-character-searches>false</one-character-searches>
       <uri-lexicon>true</uri-lexicon>
       <collection-lexicon>false</collection-lexicon>
+      <!-- For src/model/data-access.xqy ml:get-cached-navigation -->
       <directory-creation>automatic</directory-creation>
-      <maintain-last-modified>false</maintain-last-modified>
+      <maintain-last-modified>true</maintain-last-modified>
+      <maintain-directory-last-modified>true</maintain-directory-last-modified>
+      <range-element-indexes>
+        <range-element-index>
+          <namespace-uri>http://marklogic.com/xdmp/property</namespace-uri>
+          <localname>last-modified</localname>
+          <scalar-type>dateTime</scalar-type>
+          <collation/>
+          <range-value-positions>false</range-value-positions>
+        </range-element-index>
+      </range-element-indexes>
     </database>
+
     <!--Create Test Modules Database-->
     @ml.test-modules-db-xml
     <!--Create a Triggers Database-->

--- a/src/model/data-access.xqy
+++ b/src/model/data-access.xqy
@@ -101,7 +101,7 @@ return $e;
 declare variable $code-dir       := xdmp:modules-root();
 declare variable $config-file    := "navigation.xml";
 declare variable $config-dir     := concat($code-dir,'config/');
-declare variable $raw-navigation := xdmp:document-get(concat($config-dir,$config-file));
+declare variable $raw-navigation := u:get-doc(concat($config-dir,$config-file)) ;
 declare variable $public-nav-location := "/private/public-navigation.xml";
 declare variable $draft-nav-location  := "/private/draft-navigation.xml";
 declare variable $pre-generated-location := if ($draft:public-docs-only)

--- a/src/model/data-access.xqy
+++ b/src/model/data-access.xqy
@@ -666,44 +666,29 @@ declare function ml:xslt-widget($module as xs:string)
  public-navigation.xml and draft-navigation.xml
  :)
 declare function ml:get-cached-navigation()
+  as document-node()?
 {
-  let $pre-generated-navigation := doc($pre-generated-location),
-
-  $last-generated := xdmp:document-properties($pre-generated-location)/*/prop:last-modified,
-
-  $last-update :=
-
-  let $config-last-updated := xdmp:filesystem-directory($config-dir)
-  /dir:entry [dir:filename eq $config-file]
-  /dir:last-modified,
-
-  (: A happy side effect of using git is that any time we push
-   code, the .git directory should show a new last-modified date;
-   this should ensure that any and all code updates will invalidate
-   the navigation cache :)
-  $code-last-updated := xdmp:filesystem-directory($code-dir)
-  /dir:entry
-  /dir:last-modified
-
-  (: Let the admin controller code explicitly invalidate the cache rather than
-   checking the document properties all the time, which is expensive. It's also
-   insufficient, because this approach doesn't detect new documents, e.g., a new blog post.
-   ,$doc-uris := distinct-values($pre-generated-navigation//page/@href/concat(.,'.xml')),
-
-   $docs-last-updated := max(xdmp:document-properties($doc-uris)/*/prop:last-modified)
-   :)
-
-  return
-  max(($config-last-updated,
-      $code-last-updated
-      (:,
-       $docs-last-updated):)
-      ))
-
-  return
-  if (exists($pre-generated-navigation) and $last-generated gt $last-update)
-  then $pre-generated-navigation
-  else ()
+  let $pre-generated-navigation := doc($pre-generated-location)
+  let $last-generated := xdmp:document-properties(
+    $pre-generated-location)/*/prop:last-modified
+  let $last-update := max(
+    if (xdmp:modules-database() gt 0) then xdmp:invoke-function(
+      function() {
+        cts:max(
+          cts:element-reference(
+            xs:QName('prop:last-modified'), 'type=dateTime')) },
+      $u:OPTS-MODULES-DB)
+    else (
+      (: A happy side effect of using git is that any time we push
+       : code, the .git directory should show a new last-modified date.
+       : This should ensure that any and all code updates will invalidate
+       : the navigation cache.
+       :)
+      xdmp:filesystem-directory($code-dir)/dir:entry/dir:last-modified,
+      xdmp:filesystem-directory($config-dir)/dir:entry[
+        dir:filename eq $config-file]/dir:last-modified))
+  where exists($pre-generated-navigation) and $last-generated gt $last-update
+  return $pre-generated-navigation
 };
 
 (: When first populating the navigation, cache it in the database :)


### PR DESCRIPTION
This just replaces direct filesystem access with `u:get-doc`, which knows how to switch between that and a modules database. Tested ok both ways.
