### PR TITLE
Support for static views of function references

### DIFF
--- a/src/apidoc/controller/rewrite.xqm
+++ b/src/apidoc/controller/rewrite.xqm
@@ -334,6 +334,12 @@ declare function m:rewrite()
       "dotnet/xcc",
       "cpp/udf")) then m:redirect(concat($PATH, '/index.html'))
 
+  (: These two entries are a bit of a hack :)
+  else if ($PATH-TAIL = "static/xquery")
+       then "/apidoc/static/xquery.xqy?" || $QUERY-STRING
+  else if ($PATH-TAIL = "static/javascript")
+       then "/apidoc/static/javascript.xqy?" || $QUERY-STRING
+
   (: Redirect requests for older versions 301 and go to latest :)
   else if (starts-with($PATH, "/4.2")) then m:redirect-for-version('4.2')
   else if (starts-with($PATH, "/4.1")) then m:redirect-for-version('4.1')

--- a/src/apidoc/controller/rewrite.xqm
+++ b/src/apidoc/controller/rewrite.xqm
@@ -335,10 +335,18 @@ declare function m:rewrite()
       "cpp/udf")) then m:redirect(concat($PATH, '/index.html'))
 
   (: These two entries are a bit of a hack :)
-  else if ($PATH-TAIL = "static/xquery")
-       then "/apidoc/static/xquery.xqy?" || $QUERY-STRING
-  else if ($PATH-TAIL = "static/javascript")
-       then "/apidoc/static/javascript.xqy?" || $QUERY-STRING
+  else if (matches($PATH-TAIL, "static/[^/]+/xquery"))
+       then
+         let $ver := substring-before(substring-after($PATH-TAIL,"/"),"/")
+         return
+           "/apidoc/static/xquery.xqy?version=" || $ver
+           || "&amp;" || $QUERY-STRING
+  else if (matches($PATH-TAIL, "static/[^/]+/javascript"))
+       then
+         let $ver := substring-before(substring-after($PATH-TAIL,"/"),"/")
+         return
+           "/apidoc/static/javascript.xqy?version=" || $ver
+           || "&amp;" || $QUERY-STRING
 
   (: Redirect requests for older versions 301 and go to latest :)
   else if (starts-with($PATH, "/4.2")) then m:redirect-for-version('4.2')

--- a/src/apidoc/static/filter.xsl
+++ b/src/apidoc/static/filter.xsl
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:h="http://www.w3.org/1999/xhtml"
+                xmlns="http://www.w3.org/1999/xhtml"
+		exclude-result-prefixes="h xs"
+                version="2.0">
+
+<xsl:template match="/">
+  <article>
+    <xsl:apply-templates select="//h:section[@id = 'page_content']"/>
+  </article>
+</xsl:template>
+
+<xsl:template match="h:section">
+  <xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="h:script|h:noscript|h:input">
+  <!-- suppress -->
+</xsl:template>
+
+<xsl:template match="h:div[@id='comments']">
+  <!-- suppress -->
+</xsl:template>
+
+<xsl:template match="h:div[@id='copyright']">
+  <!-- suppress -->
+</xsl:template>
+
+<xsl:template match="h:div[@class='api-function-links']">
+  <!-- suppress -->
+</xsl:template>
+
+<xsl:template match="h:a[@href='?print=yes']" priority="100">
+  <!-- suppress -->
+</xsl:template>
+
+<xsl:template match="h:h1">
+  <h3>
+    <xsl:apply-templates select="@*,node()"/>
+  </h3>
+</xsl:template>
+
+<xsl:template match="h:h2">
+  <h4>
+    <xsl:apply-templates select="@*,node()"/>
+  </h4>
+</xsl:template>
+
+<xsl:template match="h:h3">
+  <h5>
+    <xsl:apply-templates select="@*,node()"/>
+  </h5>
+</xsl:template>
+
+<xsl:template match="h:h1/h:a" priority="100">
+  <xsl:value-of select="."/>
+</xsl:template>
+
+<xsl:template match="h:a[starts-with(@href, '#')]">
+  <a href="#{generate-id(/*)}.{substring-after(@href,'#')}">
+    <xsl:copy-of select="@* except @href"/>
+    <xsl:apply-templates/>
+  </a>
+</xsl:template>
+
+<xsl:template match="h:a[starts-with(@href, './')]">
+  <a href="#{substring(@href,3)}">
+    <xsl:copy-of select="@* except @href"/>
+    <xsl:apply-templates/>
+  </a>
+</xsl:template>
+
+<xsl:template match="h:a[starts-with(@href, '/js/')]">
+  <a href="#sec.{substring(@href,5)}">
+    <xsl:copy-of select="@* except @href"/>
+    <xsl:apply-templates/>
+  </a>
+</xsl:template>
+
+<xsl:template match="h:a[@name]">
+  <a name="{generate-id(/*)}.{@name}">
+    <xsl:copy-of select="@* except @name"/>
+    <xsl:apply-templates/>
+  </a>
+</xsl:template>
+
+<xsl:template match="element()">
+  <xsl:copy>
+    <xsl:apply-templates select="@*,node()"/>
+  </xsl:copy>
+</xsl:template>
+
+<xsl:template match="@id">
+  <xsl:attribute name="id">
+    <xsl:value-of select="concat(generate-id(/*), '.', .)"/>
+  </xsl:attribute>
+</xsl:template>
+
+<xsl:template match="attribute()|text()|comment()|processing-instruction()">
+  <xsl:copy/>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/src/apidoc/static/javascript.xqy
+++ b/src/apidoc/static/javascript.xqy
@@ -1,0 +1,8 @@
+xquery version "1.0-ml";
+
+import module namespace s="http://marklogic.com/rundmc/api/static"
+    at "static.xqy";
+
+declare default function namespace "http://www.w3.org/2005/xpath-functions";
+
+s:static("javascript", xdmp:get-request-field("prefix"))

--- a/src/apidoc/static/javascript.xqy
+++ b/src/apidoc/static/javascript.xqy
@@ -5,4 +5,12 @@ import module namespace s="http://marklogic.com/rundmc/api/static"
 
 declare default function namespace "http://www.w3.org/2005/xpath-functions";
 
-s:static("javascript", xdmp:get-request-field("prefix"))
+declare variable $prefix := xdmp:get-request-field("prefix");
+declare variable $version := xdmp:get-request-field("version");
+
+let $doc := doc("/apidoc/" || $version || "/Node.baseURI.xml")
+return
+  if (empty($doc))
+  then "There are no documents for " || $version || "."
+  else s:static("javascript", $version, $prefix)
+

--- a/src/apidoc/static/static.xqy
+++ b/src/apidoc/static/static.xqy
@@ -1,0 +1,137 @@
+xquery version "1.0-ml";
+
+module namespace s="http://marklogic.com/rundmc/api/static";
+
+declare default function namespace "http://www.w3.org/2005/xpath-functions";
+
+declare namespace api="http://marklogic.com/rundmc/api";
+declare namespace h="http://www.w3.org/1999/xhtml";
+
+declare option xdmp:mapping "false";
+
+declare function s:static(
+  $class as xs:string,
+  $limitpfx as xs:string*
+) as element(h:html)
+{
+  let $functions := /api:function-page[api:function/@class = $class
+                                       or api:function/@mode = $class]
+
+  (: for debugging, rename to $functions :)
+  let $xfunctions := $functions[api:function-name =
+                                  ("admin:appserver-copy",
+                                   "xdmp:document-insert",
+                                   "cts:word-query")
+                               ]
+
+  let $prefixes := distinct-values(for $prefix in ($functions/api:function/@prefix,
+                                                   $functions/api:function/@object)
+                                   where normalize-space($prefix) ne ''
+                                   return
+                                     $prefix)
+
+  (: N.B. If you specify limitpfx, then some intra-function links may
+     not resolve correctly.
+  :)
+  let $prefixes := if (empty($limitpfx))
+                   then $prefixes
+                   else $prefixes[. = $limitpfx]
+
+  (: Sort them :)
+  let $prefixes := for $prefix in $prefixes
+                   order by $prefix
+                   return $prefix
+
+  let $html := xdmp:xslt-invoke("/apidoc/view/page.xsl",
+                                document { $functions[1] })/*
+  let $head := $html/h:head
+  return
+    <html xmlns="http://www.w3.org/1999/xhtml">
+      <head>
+        <title>MarkLogic {$class} functions</title>
+        { $head/node() except ($head/h:title | $head/h:script | $head/h:style) }
+        <link href="/css/static.css" rel="stylesheet" type="text/css"/>
+      </head>
+      <body>
+        <section id="static_content">
+          <h1>MarkLogic {$class} functions</h1>
+          <div class="toc">
+            { if (count($prefixes) gt 1)
+              then
+                <p class="quicktoc">
+                  <span class="qth">Quick toc: </span>
+                  { for $prefix at $index in $prefixes
+                    return
+                      (if ($index gt 1) then " |&#160;" else (),
+                       <a href="#toc.{$prefix}">{$prefix}</a>)
+                  }
+                </p>
+              else
+                ()
+            }
+            <dl>
+              { for $prefix in $prefixes
+                let $pfuncs := $functions[api:function/@prefix = $prefix
+                                          or api:function/@object = $prefix]
+                return
+                  (<dt id="toc.{$prefix}">
+                     <a href="#sec.{$prefix}">{ $prefix }</a>
+                   </dt>,
+                   <dd>
+                     <ul>
+                       { for $func in $pfuncs
+                         order by $func/api:function-name
+                         return
+                           <li>
+                             <a href="#{$func/api:function-name}">
+                               { string($func/api:function-name) }
+                             </a>
+                           </li>
+                       }
+                     </ul>
+                   </dd>)
+              }
+            </dl>
+          </div>
+          <div class="content">
+            { for $prefix in $prefixes
+              let $pfuncs := $functions[api:function/@prefix = $prefix
+                                        or api:function/@object = $prefix]
+              return
+                <div class="prefix" id="sec.{$prefix}">
+                  <h2>{$prefix} functions</h2>
+
+                  <ul>
+                    { for $func in $pfuncs
+                      order by $func/api:function-name
+                      return
+                        <li>
+                          <a href="#{$func/api:function-name}">
+                            { string($func/api:function-name) }
+                          </a>
+                        </li>
+                    }
+                  </ul>
+
+                  { for $func in $pfuncs
+                    order by $func/api:function-name
+                    return
+                      <div class="function" id="{$func/api:function-name}">
+                        { let $html := xdmp:xslt-invoke("/apidoc/view/page.xsl",
+                                                        document { $func })
+                          let $content := xdmp:xslt-invoke("filter.xsl", $html)
+                          return
+                            $content
+                        }
+                      </div>
+                  }
+                </div>
+            }
+          </div>
+        </section>
+        <div id="copyright">
+          { substring-before(string($html/h:body//h:div[@id='copyright']), " | ") }
+        </div>
+      </body>
+    </html>
+};

--- a/src/apidoc/static/static.xqy
+++ b/src/apidoc/static/static.xqy
@@ -11,11 +11,15 @@ declare option xdmp:mapping "false";
 
 declare function s:static(
   $class as xs:string,
+  $version as xs:string,
   $limitpfx as xs:string*
 ) as element(h:html)
 {
-  let $functions := /api:function-page[api:function/@class = $class
-                                       or api:function/@mode = $class]
+  (: This is horribly inefficient. :)
+  let $path      := "/apidoc/" || $version || "/"
+  let $functions := (/api:function-page[api:function/@class = $class
+                                       or api:function/@mode = $class])
+                     [starts-with(xdmp:node-uri(.), $path)]
 
   (: for debugging, rename to $functions :)
   let $xfunctions := $functions[api:function-name =

--- a/src/apidoc/static/xquery.xqy
+++ b/src/apidoc/static/xquery.xqy
@@ -5,4 +5,12 @@ import module namespace s="http://marklogic.com/rundmc/api/static"
 
 declare default function namespace "http://www.w3.org/2005/xpath-functions";
 
-s:static("xquery", xdmp:get-request-field("prefix"))
+declare variable $prefix := xdmp:get-request-field("prefix");
+declare variable $version := xdmp:get-request-field("version");
+
+let $doc := doc("/apidoc/" || $version || "/xdmp:document-insert.xml")
+return
+  if (empty($doc))
+  then "There are no documents for " || $version || "."
+  else s:static("xquery", $version, $prefix)
+

--- a/src/apidoc/static/xquery.xqy
+++ b/src/apidoc/static/xquery.xqy
@@ -1,0 +1,8 @@
+xquery version "1.0-ml";
+
+import module namespace s="http://marklogic.com/rundmc/api/static"
+    at "static.xqy";
+
+declare default function namespace "http://www.w3.org/2005/xpath-functions";
+
+s:static("xquery", xdmp:get-request-field("prefix"))

--- a/src/css/screen.css
+++ b/src/css/screen.css
@@ -3426,4 +3426,7 @@ li.search_suggest_selected {
   top: 0;
 }
 
+#page_content .parameters blockquote { font-size: inherit; } 
+#page_content .parameters pre { font-size: inherit; } 
+
 /* screen.css */

--- a/src/css/static.css
+++ b/src/css/static.css
@@ -1,0 +1,32 @@
+/* Style for static versions of function docs */
+
+#static_content {
+   margin-left: 1rem;
+}
+
+div.prefix {
+   border-top-width: 2px;
+   border-top-color: black;
+   border-top-style: solid;
+   margin-bottom: 8rem;
+   padding-top: 1rem;
+}
+
+div.function {
+   border-top-width: 1px;
+   border-top-color: black;
+   border-top-style: dashed;
+   margin-top: 4rem;
+   padding-top: 2rem;
+}
+
+p.quicktoc {
+   padding-left: 5em;
+   text-indent: -5em;
+}
+
+span.qth {
+   display: inline-block;
+   width: 5em;
+   text-indent: 0;
+}


### PR DESCRIPTION
This pull request add support for /static/[version]/xquery and /static/[version]/javascript function references. They take a few tens of seconds to build, but are entirely static once built. Could be cached or could be made part of the build process.

Given that the build will run 4000+ transformations, I don't think it's going to be possible to make it fast enough to generate dynamically every time. That's my excuse for making no effort to be efficient in the XQuery bits :-)
