### PR TITLE
Fix for #701

### DIFF
--- a/src/apidoc/config/8.0/document-list.xml
+++ b/src/apidoc/config/8.0/document-list.xml
@@ -318,6 +318,9 @@
   Includes a glossary of terms as well as copyright and support
   information.
       </guide>
+      <guide pdf-only="true" title="Combined Product Notices" url-name="product-notices" source-name="product-notices">
+        Includes Combined Product Notices
+      </guide>
     </entry>
 
   </group>

--- a/src/apidoc/config/9.0/document-list.xml
+++ b/src/apidoc/config/9.0/document-list.xml
@@ -255,6 +255,9 @@
   Includes a glossary of terms as well as copyright and support
   information.
       </guide>
+      <guide pdf-only="true" title="Combined Product Notices" url-name="product-notices" source-name="product-notices">
+        Includes Combined Product Notices
+      </guide>
     </entry>
 
   </group>

--- a/src/apidoc/config/static-docs.xml
+++ b/src/apidoc/config/static-docs.xml
@@ -6,4 +6,5 @@
   <include>hadoop</include>
   <include>javaclient</include>
   <include>c++</include>
+  <include>pdf</include>
 </static-docs>

--- a/src/apidoc/js/toc_filter.js
+++ b/src/apidoc/js/toc_filter.js
@@ -57,7 +57,8 @@ $(function() {
       tocFilterUpdate();
       updateTocForSelection(); } });
 
-  selector = "#api_sub .pjax_enabled a:not(.external)";
+  // excluding pdf hrefs
+  selector = "#api_sub .pjax_enabled a:not(.external, [href$='.pdf'])";
   $(document).pjax(selector, '#page_content', {
     container: '#page_content',
     timeout: 4000,

--- a/src/apidoc/model/data-access.xqy
+++ b/src/apidoc/model/data-access.xqy
@@ -563,6 +563,19 @@ declare function api:external-uri($n as node())
   default return ml:external-uri-api($n)
 };
 
+(: Use this for pdf-only guides. :)
+declare function api:external-uri-pdf-only-guides($n as node())
+  as xs:string
+{   
+  let $doc-uri := base-uri($n)
+  let $version := substring-before(substring-after($doc-uri,'/apidoc/'),'/')
+  let $versionless-path := (
+    if ($version) then substring-after($doc-uri,concat('/apidoc/',$version))
+    else substring-after($doc-uri,'/apidoc'))
+  let $path := ml:unescape-uri($versionless-path)
+  return if (ends-with($path,'.xml')) then replace($path, '.xml','.pdf') else $path
+};
+
 (: ASSUMPTION: This is only called on version-less paths,
  : as they appear in the XML TOCs.
  :)

--- a/src/apidoc/setup/toc.xqm
+++ b/src/apidoc/setup/toc.xqm
@@ -528,7 +528,7 @@ as element(toc:node)
   toc:node(
     toc:id($guide),
     $guide/title treat as node(),
-    api:external-uri($guide),
+    (if ($guide/@pdf-only ne true()) then api:external-uri($guide) else api:external-uri-pdf-only-guides($guide)),
     (: If the guide node is closed, load async. Otherwise preload. :)
     $is-closed,
     'guide',

--- a/src/apidoc/view/view.xqm
+++ b/src/apidoc/view/view.xqm
@@ -104,7 +104,8 @@ as element()
   {
     if (not($in-header)) then ()
     else attribute class { 'guide-pdf-link' },
-    attribute href { $href||".pdf" },
+    (: if guide is pdf-only, not adding .pdf at the end for pdf-anchor:)
+    attribute href { (if(ends-with($href,'.pdf')) then $href else $href || '.pdf' ) },
     element img {
       attribute src { "/images/i_pdf.png" },
       attribute alt { $title||' (PDF)' },

--- a/src/model/data-access.xqy
+++ b/src/model/data-access.xqy
@@ -226,9 +226,13 @@ as xs:string+
       (: Force an error if the result is inappropriate :)
       (switch($cat)
         case 'function' return ($doc/@mode, $api:MODE-XPATH)[1]
-        case 'guide' return replace(
+        (: checking pdf-only atribute to determine category as guide-uri ends with .pdf for pdf-only guide:)
+        case 'guide' return (if($doc/@pdf-only eq true()) then replace(
           $doc/@guide-uri treat as node(),
-          '^.+/(\w[\w\-]*\w)\.xml$', '$1')
+          '^.+/(\w[\w\-]*\w)\.pdf$', '$1') else 
+        replace(
+          $doc/@guide-uri treat as node(),
+          '^.+/(\w[\w\-]*\w)\.xml$', '$1'))
         default return error((), 'ML-UNEXPECTED', ($cat, xdmp:describe($doc))))
       (: Assert that the category name is sane. :)
       ! (if (matches(., '^\w[\w\-]*\w$')) then .


### PR DESCRIPTION
Fix for serve up product notices as PDF

It expects-

- Pdf only guide has entry in document-list.xml with attributes pdf-only=true and title=“guide title”
- Corresponding pdf guide is available at pubs/pdf/[pdf-only-guide].pdf

Added entry for 8.0 and 9.0 only for product notices in document-list.xml.