### PR TITLE
switch from iframe to just link 

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -884,14 +884,12 @@ function doDownload(u) {
     }
 */
 
-  download_iframe = document.getElementById("hiddenDownloader");
-  if (download_iframe === null) {
-    download_iframe = document.createElement('iframe');
-    download_iframe.id = "hiddenDownloader";
-    download_iframe.style.visibility = 'hidden';
-    document.body.appendChild(download_iframe);
-  }
-  download_iframe.src = u;
+  let downloadLink = document.createElement('a');
+  downloadLink.href = u;
+  let path = u.split('/');
+  downloadLink.download = path[path.length - 1];
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
 
   try {
     Munchkin.munchkinFunction('clickLink', {


### PR DESCRIPTION
current download behaves by adding an iframe with src set based on URL provided. This however, handles text files in a weird way such that the content is embedded in the iframe instead of triggering a download. Switching to use of <a download href=""/> works better to handle both text files and binaries.