### PR TITLE
Docapp

### DIFF
--- a/src/apidoc/config/10.0/document-list.xml
+++ b/src/apidoc/config/10.0/document-list.xml
@@ -262,7 +262,7 @@
   Includes a glossary of terms as well as copyright and support
   information.
       </guide>
-      <guide pdf-only="true" title="Combined Product Notices" url-name="product-notices" source-name="CombinedProductNotices">
+      <guide pdf-only="true" title="Combined Product Notices" url-name="product-notices" source-name="Notice">
         The combined product notices for MarkLogic.
       </guide>
     </entry>

--- a/src/apidoc/model/data-access.xqy
+++ b/src/apidoc/model/data-access.xqy
@@ -964,7 +964,7 @@ as xs:string
 
   case 'empty-sequence()' return 'null'
 
-  case 'item()' return 'item'
+  case 'item()' return 'Item'
   case 'xs:anyURI'
   case 'xs:string'
   case 'xs:time'

--- a/src/apidoc/model/data-access.xqy
+++ b/src/apidoc/model/data-access.xqy
@@ -964,7 +964,7 @@ as xs:string
 
   case 'empty-sequence()' return 'null'
 
-  case 'item()'
+  case 'item()' return 'item'
   case 'xs:anyURI'
   case 'xs:string'
   case 'xs:time'


### PR DESCRIPTION
Changed the return of "unsignedLong" to "(Number|String)" per CJL.